### PR TITLE
Using Base.sort in order to avoid ambiguities

### DIFF
--- a/src/snoop_bot.jl
+++ b/src/snoop_bot.jl
@@ -46,7 +46,7 @@ function _snoop_analysis_bot(snooping_code, package_name, precompile_folder, sub
             end
             """)
         else # if any precompilation script is generated
-            onlypackage = Dict( packageSym => sort(pc[packageSym]) )
+            onlypackage = Dict( packageSym => Base.sort(pc[packageSym]) )
             SnoopCompile.write($precompile_folder, onlypackage)
             @info "precompile signatures were written to $($precompile_folder)"
         end


### PR DESCRIPTION
There are package that are providing a `sort` implementation as well. This leads to the following error, e.g. with Redis.jl
```julia-repl
WARNING: both Redis and Base export "sort"; uses of it in module Main must be qualified
ERROR: UndefVarError: sort not defined
```
