### PR TITLE
Reduce risks of clashes with package identifiers

### DIFF
--- a/src/snoop_bench.jl
+++ b/src/snoop_bench.jl
@@ -5,14 +5,14 @@ function _snoopi_bench_cmd(snoop_script)
         global SnoopCompile_ENV = true
         using SnoopCompileCore
 
-        data = @snoopi tmin=$tmin begin
+        __the_data__ = @snoopi tmin=$tmin begin
             $snoop_script
         end
 
         global SnoopCompile_ENV = false
 
         using CompileBot: timesum
-        @info( "\nTotal inference time (ms): \t" * string(timesum(data, :ms)))
+        @info( "\nTotal inference time (ms): \t" * string(timesum(__the_data__, :ms)))
     end
 end
 


### PR DESCRIPTION
Running CompileBot failed for me in a package which exports a function
named `data`. Resolve this by renaming the global variable `data` used
by CompileBot to `__the_data__` which should minimize the risk of clashes.

Also changed some more quoted code to use `let` to avoid similar problems
for `pc` and `packageSym`.
