### PR TITLE
run in active environment instead of directory

### DIFF
--- a/src/botutils.jl
+++ b/src/botutils.jl
@@ -224,7 +224,7 @@ function pathof_noload(package_name::String)
             return GoodPath(path)
         catch
             try
-                path = Base.read(`$(Base.julia_cmd()) --project=@. -e $cmd`, String)
+                path = Base.read(`$(Base.julia_cmd()) --project=$(Base.active_project()) -e $cmd`, String)
                 return GoodPath(path)
             catch
                 @error "Couldn't find the path of $package_name"

--- a/src/snoop_bench.jl
+++ b/src/snoop_bench.jl
@@ -56,7 +56,7 @@ function _snoop_bench(config::BotConfig, snoop_script::Expr, test_modul::Module 
         code_coverage = "none"
     end
 
-    julia_cmd = `$(Base.julia_cmd()) --code-coverage=$code_coverage --project=@. -e $snooping_code`
+    julia_cmd = `$(Base.julia_cmd()) --code-coverage=$code_coverage --project=$(Base.active_project()) -e $snooping_code`
 
     addpkg_ifnotfound(:SnoopCompileCore, test_modul)
     out = quote

--- a/src/snoop_bot.jl
+++ b/src/snoop_bot.jl
@@ -121,7 +121,7 @@ function _snoop_bot_expr(config::BotConfig, snoop_script, test_modul::Module; sn
         code_coverage = "none"
     end
 
-    julia_cmd = `$(Base.julia_cmd()) --code-coverage=$code_coverage --project=@. -e $snooping_analysis_code`
+    julia_cmd = `$(Base.julia_cmd()) --code-coverage=$code_coverage --project=$(Base.active_project()) -e $snooping_analysis_code`
 
     addpkg_ifnotfound(:SnoopCompileCore, test_modul)
     addpkg_ifnotfound(:SnoopCompile, test_modul)


### PR DESCRIPTION
If you use e.g. the global environment instead of the package environment this may break because of missing dependencies