### PR TITLE
Run CI tests in more Julia versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           - '1.0'
           - '1.2'
           - '1.5'
+          - '1.6'
+          - '1.8'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Julia 1.6 is TLS, and 1.8 the latest.

I would suggest to drop 1.2 and 1.5 instead.